### PR TITLE
Fix for "weird" behaviour causing Subscript out of Range error when r…

### DIFF
--- a/src/cBiff12Part.cls
+++ b/src/cBiff12Part.cls
@@ -1861,7 +1861,10 @@ End Function
 '= shared strings table ==================================================
 
 Public Function SstGetIndex(sText As String) As Long
-    SstGetIndex = m_uaSstHashEntries(pvSstGetInternal(sText)).Index
+    Dim lIdx            As Long
+    
+    lIdx = pvSstGetInternal(sText)
+    SstGetIndex = m_uaSstHashEntries(lIdx).Index
 End Function
 
 Public Function SstGetPosition(sText As String) As Long


### PR DESCRIPTION
…unning under Linux/Wine.

Problem: Under Linux/Wine (at least some versions), we'll get a 9-Subscript out of Range error in cBiff12Part.SstGetIndex. It appears that the inline call to pvSstGetInternal(sText) isn't being executed before the code tries to grab an element from the m_uaSstHashEntries array, so it isn't being dimensioned first. This is not a problem on Windows hosts.

Very strange stuff, and unfortunately I haven't been able to determine why this happens, but the "fix" is simple enough and doesn't change any existing functionality so I suspect it is a very safe modification. We simply call pvSstGetInternal and store the returned index *before* referencing m_uaSstHashEntries to force it to execute the array initialization code before attempting to access any elements.


Signed-off-by: Jason Peter Brown <jason@bitspaces.com>