### PR TITLE
Use intermediary local variable for index returned from pvSstGetInternal

### DIFF
--- a/src/cBiff12Part.cls
+++ b/src/cBiff12Part.cls
@@ -1868,7 +1868,10 @@ Public Function SstGetIndex(sText As String) As Long
 End Function
 
 Public Function SstGetPosition(sText As String) As Long
-    SstGetPosition = m_uaSstHashEntries(pvSstGetInternal(sText)).KeyPosition
+    Dim lIdx            As Long
+    
+    lIdx = pvSstGetInternal(sText)
+    SstGetPosition = m_uaSstHashEntries(lIdx).KeyPosition
 End Function
 
 Public Function pvSstGetInternal(sText As String) As Long


### PR DESCRIPTION
…before using against m_uaSstHashEntries array as per discussion here: https://github.com/jpbro/Biff12Writer/commit/73d29f1c61d623b87d8c095ff9f306bcfa3a742a

Signed-off-by: Jason Peter Brown <jason@bitspaces.com>